### PR TITLE
Change console kernel message loglevel from WARNING to ALERT

### DIFF
--- a/rootfiles/boot/cmdline.txt
+++ b/rootfiles/boot/cmdline.txt
@@ -1,1 +1,1 @@
-root=/dev/mmcblk0p2 rw rootwait console=ttyAMA0,115200 kgdboc=ttyAMA0,115200 console=tty6 smsc95xx.turbo_mode=N dwc_otg.lpm_enable=0 loglevel=4 elevator=noop vt.global_cursor_default=0
+root=/dev/mmcblk0p2 rw rootwait console=ttyAMA0,115200 kgdboc=ttyAMA0,115200 console=tty6 smsc95xx.turbo_mode=N dwc_otg.lpm_enable=0 loglevel=1 elevator=noop vt.global_cursor_default=0


### PR DESCRIPTION
Otherwise there are too much ugly unnecessary messages often printed to the screen for the user. And when stuff like #24 is hit, it's really bad. Basically, your screen will be full of kernel messages each time you go out of sleep, until you tap screen to refresh.

```
loglevel=       All Kernel Messages with a loglevel smaller than the
                    console loglevel will be printed to the console. It can
                    also be changed with klogd or other programs. The
                    loglevels are defined as follows:

                    0 (KERN_EMERG)          system is unusable
                    1 (KERN_ALERT)          action must be taken immediately
                    2 (KERN_CRIT)           critical conditions
                    3 (KERN_ERR)            error conditions
                    4 (KERN_WARNING)        warning conditions
                    5 (KERN_NOTICE)         normal but significant condition
                    6 (KERN_INFO)           informational
                    7 (KERN_DEBUG)          debug-level messages
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced kernel log message verbosity during boot and runtime, showing only critical messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->