### PR TITLE
Increase swapfile size from 2G to 4G

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ set up the SSD:
 
 add swap:
 
-    dd if=/dev/zero of=/ssd/swapfile bs=1M count=2048
+    dd if=/dev/zero of=/ssd/swapfile bs=1M count=4096
     chmod 600 /ssd/swapfile
     mkswap /ssd/swapfile
     echo "/ssd/swapfile   none    swap    sw,nofail 0 0" >> /etc/fstab


### PR DESCRIPTION
Better to have more than less in our case. Official Void Linux recommendations (https://docs.voidlinux.org/installation/live-images/partitions.html#swap-partitions) for 2-8G systems is "equal to amount of RAM".

With too small swap space (I had old Nakamochi with 1G swapfile) user will notice freezing and slow screen unlock when system has too small amount of available memory. Then only workaround, unless you have ssh access, is turning it off and on again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated system setup documentation to specify increased swap space allocation during configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->