### PR TITLE
Fix lnd.mainnet.conf

### DIFF
--- a/rootfiles/home/lnd/lnd.mainnet.conf
+++ b/rootfiles/home/lnd/lnd.mainnet.conf
@@ -1,6 +1,6 @@
 ; https://docs.lightning.engineering/lightning-network-tools/lnd/lnd.conf
 
-[application options]
+[Application Options]
 alias=nakamochi
 ;wallet-unlock-password-file=/home/lnd/walletunlock.txt
 debuglevel=info
@@ -16,18 +16,15 @@ rpclisten=0.0.0.0:10009
 restlisten=0.0.0.0:10010
 wtclient.active=true
 
-[autopilot]
+[Autopilot]
 autopilot.active=false
 
-[bitcoin]
+[Bitcoin]
 bitcoin.chaindir=/ssd/lnd/data/chain/mainnet
 bitcoin.mainnet=true
-bitcoin.testnet=false
-bitcoin.regtest=false
-bitcoin.simnet=false
 bitcoin.node=bitcoind
 
-[bitcoind]
+[Bitcoind]
 bitcoind.rpchost=127.0.0.1
 bitcoind.rpcuser=rpc
 bitcoind.rpcpass=${rpcauth}
@@ -40,7 +37,7 @@ bitcoind.zmqpubrawtx=tcp://127.0.0.1:8330
 db.bolt.auto-compact=true
 db.bolt.auto-compact-min-age=168h
 
-[tor]
+[Tor]
 tor.active=true
 tor.skip-proxy-for-clearnet-targets=true
 tor.v3=true


### PR DESCRIPTION
Previous version had error - `lnd: failed to load config: ValidateConfig: either --bitcoin.mainnet, or --bitcoin.testnet, --bitcoin.testnet4, --bitcoin.simnet, --bitcoin.regtest or --bitcoin.signet must be specified`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardised configuration file section header formatting for consistency.
  * Removed explicit default configuration flags from Bitcoin settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->