### PR TITLE
Change file ownership for lnd configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ set up lnd lightning configuration:
     # copy lnd config file
     scp rootfiles/home/lnd/lnd.mainnet.conf root@target:/home/lnd/
     chmod 640 /home/lnd/lnd.mainnet.conf
-    chgrp lnd /home/lnd/lnd.mainnet.conf
+    chown lnd:lnd /home/lnd/lnd.mainnet.conf
 
 generate bitcoind RPC auth credentials:
 


### PR DESCRIPTION
This is now needed after #35 and https://github.com/nakamochi/sysupdates/pull/52.

Otherwise LND fails at startup with confusing error `lnd: failed to load config: ValidateConfig: either --bitcoin.mainnet, or --bitcoin.testnet, --bitcoin.testnet4, --bitcoin.simnet, --bitcoin.regtest or --bitcoin.signet must be specified` although actual error is that it can't access `/home/lnd/lnd.mainnet.conf`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated lnd setup instructions to provide clearer guidance on configuring file ownership and permissions during the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->