### PR TITLE
rpi: disable UAS for SanDisk 0781:55b0 USB SSD

### DIFF
--- a/rootfiles/boot/cmdline.txt
+++ b/rootfiles/boot/cmdline.txt
@@ -1,1 +1,1 @@
-root=/dev/mmcblk0p2 rw rootwait console=ttyAMA0,115200 kgdboc=ttyAMA0,115200 console=tty6 smsc95xx.turbo_mode=N dwc_otg.lpm_enable=0 loglevel=1 elevator=noop vt.global_cursor_default=0
+root=/dev/mmcblk0p2 rw rootwait console=ttyAMA0,115200 kgdboc=ttyAMA0,115200 console=tty6 smsc95xx.turbo_mode=N dwc_otg.lpm_enable=0 loglevel=1 elevator=noop vt.global_cursor_default=0 usb-storage.quirks=0781:55b0:u


### PR DESCRIPTION
Force the SanDisk USB SSD (0781:55b0) off UAS and onto usb-storage BOT. This avoids uas_eh_abort_handler / stalled I/O issues seen on Raspberry Pi 4 with this device. The quirk is VID:PID-specific and has no effect on unrelated USB drives.

Should fix these kind of errors:

```
[45263.557297] sd 0:0:0:0: [sda] tag#21 uas_eh_abort_handler 0 uas-tag 1 inflight: CMD
[45263.557335] sd 0:0:0:0: [sda] tag#21 CDB: Read(10) 28 00 0e 56 53 78 00 04 00 00
[45263.557356] sd 0:0:0:0: [sda] tag#19 uas_eh_abort_handler 0 uas-tag 2 inflight: CMD
[45263.557369] sd 0:0:0:0: [sda] tag#19 CDB: Read(10) 28 00 0e 56 57 78 00 04 00 00
[45263.557387] sd 0:0:0:0: [sda] tag#17 uas_eh_abort_handler 0 uas-tag 4 inflight: CMD
[45263.557399] sd 0:0:0:0: [sda] tag#17 CDB: Read(10) 28 00 01 f5 db 80 00 00 10 00
[45263.557415] sd 0:0:0:0: [sda] tag#16 uas_eh_abort_handler 0 uas-tag 3 inflight: CMD
[45263.557426] sd 0:0:0:0: [sda] tag#16 CDB: Read(10) 28 00 0e 56 5b 78 00 04 00 00
[45264.557310] sd 0:0:0:0: [sda] tag#24 uas_eh_abort_handler 0 uas-tag 5 inflight: CMD
[45264.557343] sd 0:0:0:0: [sda] tag#24 CDB: Read(10) 28 00 01 c5 a9 90 00 00 08 00
[45266.437350] sd 0:0:0:0: [sda] tag#29 uas_eh_abort_handler 0 uas-tag 7 inflight: CMD
[45266.437389] sd 0:0:0:0: [sda] tag#29 CDB: Write(10) 2a 00 0e 4d 83 e0 00 03 88 00
[45266.437412] sd 0:0:0:0: [sda] tag#28 uas_eh_abort_handler 0 uas-tag 6 inflight: CMD
[45266.437425] sd 0:0:0:0: [sda] tag#28 CDB: Write(10) 2a 00 03 45 b4 f0 00 00 08 00
[45267.725365] sd 0:0:0:0: [sda] tag#22 uas_eh_abort_handler 0 uas-tag 8 inflight: CMD
[45267.725395] sd 0:0:0:0: [sda] tag#22 CDB: Write(10) 2a 00 3a 12 46 78 00 00 20 00
[45281.221585] sd 0:0:0:0: [sda] tag#23 uas_eh_abort_handler 0 uas-tag 9 inflight: CMD
[45281.221629] sd 0:0:0:0: [sda] tag#23 CDB: Read(10) 28 00 01 b2 39 f0 00 00 08 00
[45284.293635] sd 0:0:0:0: [sda] tag#20 uas_eh_abort_handler 0 uas-tag 10 inflight: CMD
[45284.293675] sd 0:0:0:0: [sda] tag#20 CDB: Read(10) 28 00 01 ac 43 88 00 00 08 00
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified system boot configuration to update USB storage device handling during the startup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->