### PR TITLE
socklog: reduce SD card writes by enabling svlogd buffering

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ update the system, reboot if requested and install system logging:
     xbps-install -Su
     xbps-install -u xbps
     xbps-install socklog-void
+    scp rootfiles/etc/sv/socklog-unix/log/run root@target:/etc/sv/socklog-unix/log/
     ln -s /etc/sv/socklog-unix /var/service/
     ln -s /etc/sv/nanoklogd /var/service/
 

--- a/rootfiles/etc/sv/socklog-unix/log/run
+++ b/rootfiles/etc/sv/socklog-unix/log/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec svlogd -tt -b 65536 -l 2000 /var/log/socklog/* #2>/dev/tty12


### PR DESCRIPTION
Switch svlogd from immediate line-based flushing to buffered writes to better suit SD card-backed systems.

Changes:
- replace -ttt with -tt
  * keep timestamps while slightly reducing per-line overhead
  * nanosecond precision from -ttt is not required in this setup

- add -b 65536
  * enable 64KB in-memory buffering
  * reduces write amplification by batching disk writes
  * introduces small delay in svlogtail visibility
  * acceptable trade-off for significantly lower SD wear

- add -l 2000
  * increase maximum line length from default (1000 bytes)
  * prevents truncation of longer log lines (e.g. kernel, xbps)

Result:
- significantly fewer and larger disk writes
- lower SD card wear
- minimal impact on real-time log observation (observed delay ~1s)
- no change to logging pipeline or tooling (svlogtail still works)

This keeps the setup simple while improving durability for flash-based storage.

Current default `/etc/sv/socklog-unix/log/run` before this change is:
```
#!/bin/sh
exec svlogd -ttt /var/log/socklog/* #2>/dev/tty12
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated system logging setup documentation with refined configuration process.

* **New Features**
  * Added logging service script with configurable time-stamping and buffering for improved system logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->