### PR TITLE
make Tor data directory group readable

### DIFF
--- a/rootfiles/etc/tor/torrc
+++ b/rootfiles/etc/tor/torrc
@@ -7,6 +7,7 @@
 User tor
 Log notice syslog
 DataDirectory /ssd/tor
+DataDirectoryGroupReadable 1
 
 ControlPort 9051
 CookieAuthentication 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Tor configuration to enable group-readable permissions for the data directory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nakamochi/img/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->