### PR TITLE
bitcoin: allow group access to RPC cookie

### DIFF
--- a/rootfiles/home/bitcoind/mainnet.conf
+++ b/rootfiles/home/bitcoind/mainnet.conf
@@ -22,6 +22,7 @@ rpcallowip=127.0.0.1
 # rpcauth.py rpc
 # ${rpcauth}
 rpcauth=${rpcauth_hash}
+rpccookieperms=group
 
 # push data over ZMQ to lnd
 zmqpubrawblock=tcp://127.0.0.1:8331


### PR DESCRIPTION
Set rpccookieperms=group so local services in the bitcoind group can authenticate with Bitcoin Core using the RPC cookie.

Works with Bitcoin Core >= 28.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Bitcoin Core RPC permissions configuration to allow group-level access to the RPC cookie, enabling broader shared access to remote procedure calls within group-based deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->